### PR TITLE
Add limit to number of results to display in a group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 src/dist/**/*.css
 src/dist/**/*.js
+.idea

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The following settings can be set on a per-instance basis via _dasherized_ `<amo
 | `isFilterEnabled` | `<boolean` | Yes | `true` | State of search filter input visibility |
 | `isSelectAllEnabled` | `<boolean` | Yes | `true` | State of select all functionality |
 | `label` | `&string` | No | — | Expression bound to the current button label text |
+| `limitTo` | `&number` | No | 500 | Number of options to show per group. This is a high-bound limit so that browser performance won't suffer with large data sets. Specify `0` or `false` to disable limiting. |
 | `onChange` | `&function(label)` | No | — | Expression called with `label` string when model changes |
 | `onToggleDropdown` | `&function(isOpen)` | No | — | Expression called with `isOpen` boolean when dropdown opens or closes |
 | `selectAllText` | `@string` | Yes | Select&nbsp;All | Select all option label text |

--- a/src/app/app.controller.js
+++ b/src/app/app.controller.js
@@ -29,6 +29,7 @@
         ];
         self.modelObjectProperty = [2];
         self.modelStringTwo = ['One', 'Two'];
+        self.modelLongString = ['One', 'Two'];
         self.optionsObject = [
             {
                 id: 1,
@@ -75,6 +76,28 @@
             'One',
             'Two',
             'Three'
+        ];
+        self.optionsLongString = [
+            'One',
+            'Two',
+            'Three',
+            'Four',
+            'Five',
+            'Six',
+            'Seven',
+            'Eight',
+            'Nine',
+            'Ten',
+            'Eleven',
+            'Twelve',
+            'Thirteen',
+            'Fourteen',
+            'Fifteen',
+            'Sixteen',
+            'Seventeen',
+            'Eighteen',
+            'Nineteen',
+            'Twenty'
         ];
 
         self.addObject = addObject;

--- a/src/content/styles/multiselect.scss
+++ b/src/content/styles/multiselect.scss
@@ -106,5 +106,19 @@
                 text-decoration: none;
             }
         }
+
+        > li.dropdown-is-over-limit {
+            border-top: 1px solid fade-out($text-muted, 0.7);
+            font-size: 0.9em;
+            font-style: italic;
+            padding: 7px 12px 5px;
+            text-align: center;
+
+            &.dropdown-is-group-limit {
+                border-top: none;
+                padding: 5px 12px 12px 32px;
+                text-align: left;
+            }
+        }
     }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -96,6 +96,23 @@
                 </div>
             </div>
             <div class="panel panel-default">
+                <div class="panel-heading">Limited Result Set</div>
+                <div class="panel-body">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <amo-multiselect
+                                limit-to="10"
+                                ng-model="app.modelLongString"
+                                options="option for option in app.optionsLongString">
+                            </amo-multiselect>
+                        </div>
+                        <div class="col-md-6">
+                            <pre>{{ app.modelLongString }}</pre>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="panel panel-default">
                 <div class="panel-heading">Deferred Load, Events & Custom Text</div>
                 <form class="panel-body" name="app.form">
                     <div class="row">

--- a/src/lib/multiselect-config.constant.js
+++ b/src/lib/multiselect-config.constant.js
@@ -16,6 +16,7 @@
             isDisabled: false,
             isFilterEnabled: true,
             isSelectAllEnabled: true,
+            limitTo: 500,
             selectAllText: 'Select All',
             selectedSuffixSingularText: 'item',
             selectedSuffixText: 'items',

--- a/src/lib/multiselect-dropdown.html
+++ b/src/lib/multiselect-dropdown.html
@@ -40,13 +40,19 @@
                 ng-if="multiselectDropdown.isGroupVisible(group)"
                 ng-repeat-start="group in multiselectDropdown.groups">
             </li>
-            <li ng-repeat="option in multiselectDropdown.optionsFiltered[group] = (multiselectDropdown.groupOptions[group] | filter : multiselectDropdown.filter)">
+            <li ng-repeat="option in (multiselectDropdown.optionsFiltered[group] = (multiselectDropdown.groupOptions[group] | filter : multiselectDropdown.filter)) | limitTo: multiselectDropdown.limit">
                 <a
                     ng-attr-title="{{ option.label }}"
                     ng-click="multiselectDropdown.toggleSelectedState(option)">
                     <input type="checkbox" ng-model="option.selected">
                     <span ng-bind="option.label"></span>
                 </a>
+            </li>
+            <li
+                class="dropdown-is-over-limit"
+                ng-class="{ 'dropdown-is-group-limit': group !== null }"
+                ng-show="multiselectDropdown.countOptionsAfterLimit(group)">
+                <span ng-bind="multiselectDropdown.countOptionsAfterLimit(group)"></span> more result(s).<span ng-if="::multiselectDropdown.state.isFilterEnabled"><br>Search to reveal more.</span>
             </li>
             <li ng-repeat-end></li>
         </ul>

--- a/src/lib/multiselect.directive.js
+++ b/src/lib/multiselect.directive.js
@@ -55,7 +55,7 @@
             self.groupOptions = {};
             self.optionsFiltered = {};
             self.filter = {};
-            self.limit = getSettingValue('limitTo', true) || 500;
+            self.limit = getSettingValue('limitTo', true);
             self.state = {
                 isDeselectAllEnabled: _isDeselectAllEnabled,
                 isDisabled: getSettingValue('isDisabled', true),

--- a/src/lib/multiselect.directive.js
+++ b/src/lib/multiselect.directive.js
@@ -55,6 +55,7 @@
             self.groupOptions = {};
             self.optionsFiltered = {};
             self.filter = {};
+            self.limit = getSettingValue('limitTo', true) || 500;
             self.state = {
                 isDeselectAllEnabled: _isDeselectAllEnabled,
                 isDisabled: getSettingValue('isDisabled', true),
@@ -70,6 +71,7 @@
             };
 
             // Methods
+            self.countOptionsAfterLimit = countOptionsAfterLimit;
             self.exposeSelectedOptions = exposeSelectedOptions;
             self.getSelectedCount = getSelectedCount;
             self.hasSelectedMultipleItems = hasSelectedMultipleItems;
@@ -88,6 +90,22 @@
              */
             function addLabel(option) {
                 _labels.push(multiselect.getLabel(option));
+            }
+
+            /**
+             * @ngdoc method
+             * @name amoMultiselect#countOptionsAfterLimit
+             * @description Determines whether or not there are options after the limit is imposed for the specified group
+             * @param {String} The group to count options for
+             * @returns {boolean}
+             */
+            function countOptionsAfterLimit(group) {
+                if (angular.isUndefined(group)) {
+                    group = null;
+                }
+
+                var diff = self.optionsFiltered[group].length - self.limit;
+                return (diff > 0) ? diff : 0;
             }
 
             /**

--- a/src/lib/multiselect.directive.js
+++ b/src/lib/multiselect.directive.js
@@ -100,10 +100,17 @@
              * @returns {boolean}
              */
             function countOptionsAfterLimit(group) {
+                // if the limit isn't set, then all items are returned
+                if (angular.isUndefined(self.limit)) {
+                    return 0;
+                }
+
+                // set the default group
                 if (angular.isUndefined(group)) {
                     group = null;
                 }
 
+                // compute the difference
                 var diff = self.optionsFiltered[group].length - self.limit;
                 return (diff > 0) ? diff : 0;
             }
@@ -260,6 +267,11 @@
                 ngModelController.$isEmpty = function(value) {
                     return !angular.isArray(value) || value.length === 0;
                 };
+
+                // If the limit is set to 0, false, or null...set the value to undefined (this effectively disables the limitTo filter)
+                if (self.limit === 0 || self.limit === false || self.limit === null) {
+                    self.limit = undefined;
+                }
             }
 
             /**

--- a/src/lib/multiselect.directive.js
+++ b/src/lib/multiselect.directive.js
@@ -268,8 +268,8 @@
                     return !angular.isArray(value) || value.length === 0;
                 };
 
-                // If the limit is set to 0, false, or null...set the value to undefined (this effectively disables the limitTo filter)
-                if (self.limit === 0 || self.limit === false || self.limit === null) {
+                // If the limit is defined but falsey (0, false, null) then disable the limit functionality
+                if (angular.isDefined(self.limit) && !Boolean(self.limit)) {
                     self.limit = undefined;
                 }
             }

--- a/tests/lib/multiselect.directive.spec.js
+++ b/tests/lib/multiselect.directive.spec.js
@@ -25,6 +25,7 @@ describe('amoMultiselect', function() {
             isDisabled: false,
             isFilterEnabled: true,
             isSelectAllEnabled: true,
+            limitTo: 500,
             selectAllText: 'Select All',
             selectedSuffixSingularText: 'item',
             selectedSuffixText: 'items',

--- a/tests/lib/multiselect.directive.spec.js
+++ b/tests/lib/multiselect.directive.spec.js
@@ -63,6 +63,8 @@ describe('amoMultiselect', function() {
             null: optionsMock
         });
 
+        amoMultiselectFactoryInstanceSpy.getOptionsCount.and.returnValue(optionsMock.length);
+
         amoMultiselectFactoryInstanceSpy.getOptionsExpression.and.returnValue('options');
 
         amoMultiselectFactoryInstanceSpy.getLabel.and.callFake(function(option) {
@@ -169,6 +171,10 @@ describe('amoMultiselect', function() {
                 expect(target.groups).toEqual([
                     null
                 ]);
+            });
+
+            it('should set the default limit', function() {
+                expect(target.limit).toEqual(500);
             });
 
             it('should expose options', function() {
@@ -438,6 +444,24 @@ describe('amoMultiselect', function() {
 
             it('should expose state', function() {
                 expect(target.state.isDisabled).toEqual(true);
+            });
+        });
+
+        describe('with the "limitTo" specified', function() {
+            beforeEach(function() {
+                compile('<amo-multiselect limit-to="1" ng-model="model" options="option for option in options"></amo-multiselect>', {
+                    options: optionsMock
+                });
+
+                target.optionsFiltered = {null: ['One', 'Two']};
+            });
+
+            it('should set the limit', function() {
+                expect(target.limit).toEqual(1);
+            });
+
+            it('should know that there are more options than the limit', function() {
+                expect(target.countOptionsAfterLimit()).toEqual(1);
             });
         });
     });

--- a/tests/lib/multiselect.directive.spec.js
+++ b/tests/lib/multiselect.directive.spec.js
@@ -465,6 +465,23 @@ describe('amoMultiselect', function() {
                 expect(target.countOptionsAfterLimit()).toEqual(1);
             });
         });
+
+        describe('with the "limitTo" disabled', function() {
+            beforeEach(function() {
+                compile('<amo-multiselect limit-to="false" ng-model="model" options="option for option in options"></amo-multiselect>', {
+                    options: optionsMock
+                });
+                target.optionsFiltered = {null: ['One', 'Two']};
+            });
+
+            it('should set the limit', function() {
+                expect(target.limit).toEqual(undefined);
+            });
+
+            it('should know that there are more options than the limit', function() {
+                expect(target.countOptionsAfterLimit()).toEqual(0);
+            });
+        });
     });
 
     describe('When compiling the directive with an array of objects with two items selected', function() {


### PR DESCRIPTION
This is to prevent large result sets (thousands) from having poor DOM performance.